### PR TITLE
fix: Fixes to satisfy linter

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -17,6 +17,6 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --base . --verbose --no-progress './**/*.md' --accept 100..=103,200..=299,429
+          args: --base . --verbose --no-progress './**/*.md' --accept 100..=103,200..=299,429 --exclude 'https://stackoverflow.com/*'
           format: markdown
           fail: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM eclipse-temurin:21-alpine
 
-MAINTAINER qubership.org
+LABEL maintainer="qubership.org"
+LABEL org.opencontainers.image.authors="qubership.org"
+LABEL org.opencontainers.image.description="Qubership Inventory Tool CLI"
+LABEL org.opencontainers.image.source="https://github.com/netcracker/qubership-inventory-tool-cli"
 
 RUN mkdir /app
 COPY target/qubership-inventory-tool-cli-*-fat.jar /app/inventory-tool.jar


### PR DESCRIPTION
- Updated labels in Dockerfile to use more modern approach.
- For link checker had to exclude the link checks for Stack Overflow because it forbids automatic access, so it will always fail when you open those link with automatic tools like link checker. 